### PR TITLE
Update copyright to 2025; add GitHub and Discourse links to website

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   title: "GATE-DA"
 
 website:
-  page-footer: "Copyright 2024 @ IIT Madras"
+  page-footer: "Copyright 2025 @ IIT Madras"
   page-navigation: true
   sidebar:
     logo: "assets/iit_logo.png"
@@ -12,6 +12,10 @@ website:
     foreground: "primary"
     contents: auto
     search: true
+  repo-url: https://github.com/iitmbsc-student-projects/gate-da
+  repo-branch: master
+  repo-actions: [edit, issue, source]
+  repo-link-target: "_blank"
   #announcement: 
   #  icon: info-circle
   #  dismissable: true
@@ -33,3 +37,7 @@ format:
     highlight-style: github
     code-block-border-left: "#D3D3D3"
     code-overflow: scroll
+    other-links:
+      - text: Discussion Forum
+        icon: chat-square-dots-fill
+        href: https://discourse.onlinedegree.iitm.ac.in/c/sca/gate-dojo/98


### PR DESCRIPTION

### 📝 Description

This pull request introduces the following updates to the project:

chore: update copyright to 2025

feat: add GitHub Edit, Source, and Issue links to each page

feat: add link to GATE Dojo Discourse category


- Added **GitHub repository actions** (`Edit`, `Source`, `Report Issue`) to every page.
- Updated the copyright year to **2025**.
- Added a link to the **Gate Dojo Category** on the Discourse forum for further discussions.

These changes aim to improve content accessibility, encourage user contributions, and ensure metadata accuracy for 2025.

---

### 🔗 Related

- Repository actions configured via `_quarto.yml`.
- Discourse forum link added for community engagement.

---

### ✅ Checklist

- [x] Configuration verified across multiple pages.
- [x] Links tested for proper redirection.
- [x] No build or rendering errors observed.

---
Closes #8 

